### PR TITLE
Limit stackUpdateThreads to prevent overwhelming the swarm manager

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -4,6 +4,11 @@
 # waits everytime before pulling 
 update_interval: 120
 
+# The amount of parallel threads for deploying stacks.
+# The sensible value depends on the setup to prevent
+# the swarm manager from overloading.
+concurrency: 3
+
 # The path where SwarmCD will checkout repos
 repos_path: repos/
 

--- a/swarmcd/init.go
+++ b/swarmcd/init.go
@@ -112,7 +112,7 @@ func initStacks() error {
 	var newStackStatus = map[string]*StackStatus{}
 
 	for stack, stackConfig := range config.StackConfigs {
-		logger.Info(fmt.Sprintf("reading stackConfig for stack: %v", stack))
+		logger.Debug(fmt.Sprintf("reading stackConfig for stack: %v", stack))
 
 		stackRepo, ok := repos[stackConfig.Repo]
 		if !ok {

--- a/swarmcd/stack.go
+++ b/swarmcd/stack.go
@@ -68,7 +68,7 @@ func (swarmStack *swarmStack) updateStack() (stackMetadata *stackMetadata, err e
 		logger.Info(fmt.Sprintf("%s no last revision found", swarmStack.name))
 	}
 
-	logger.Info(fmt.Sprintf("%s new revision revision found %s! will update the stack", swarmStack.name, revision))
+	logger.Info(fmt.Sprintf("%s new revision revision found %s! Checking if stack deployment needed...", swarmStack.name, revision))
 
 	log.Debug("reading stack file...")
 	stackBytes, err := swarmStack.readStack()
@@ -287,11 +287,11 @@ func (swarmStack *swarmStack) shouldDeploy(newMetadata *stackMetadata, deployedM
 	logger.Debug(fmt.Sprintf("%s Old Stack hash: %s", swarmStack.name, deployedMetadata.fmtHash()))
 	logger.Debug(fmt.Sprintf("%s New Stack hash: %s", swarmStack.name, newMetadata.fmtHash()))
 	if newMetadata.hash == deployedMetadata.hash {
-		logger.Info(fmt.Sprintf("%s stack file hash unchanged, hash=%s. Will skip deployment of revision: %s", swarmStack.name, deployedMetadata.fmtHash(), newMetadata.repoRevision))
+		logger.Info(fmt.Sprintf("%s stack file hash unchanged, hash=%s. Skipping deployment.", swarmStack.name, deployedMetadata.fmtHash()))
 		logger.Info(fmt.Sprintf("%s stack remains at revision: %s", swarmStack.name, deployedMetadata.deployedStackRevision))
 		return false
 	}
-	logger.Info(fmt.Sprintf("%s new stack file with hash=%s found. Will continue with deployment of revision: %s", swarmStack.name, newMetadata.fmtHash(), newMetadata.repoRevision))
+	logger.Info(fmt.Sprintf("%s new stack file with hash=%s found. Deploying revision: %s", swarmStack.name, newMetadata.fmtHash(), newMetadata.repoRevision))
 	return true
 }
 

--- a/swarmcd/swarmcd.go
+++ b/swarmcd/swarmcd.go
@@ -3,8 +3,6 @@ package swarmcd
 import (
 	"fmt"
 	"github.com/m-adawi/swarm-cd/util"
-	"os"
-	"strconv"
 	"sync"
 	"time"
 )
@@ -15,21 +13,15 @@ var stacks = map[string]*swarmStack{}
 func getWorkerCount() int {
 	const defaultWorkers = 3
 
-	workerStr := os.Getenv("SWARMCD_CONCURRENCY")
-	if workerStr == "" {
-		return defaultWorkers
-	}
-
-	workerCount, err := strconv.Atoi(workerStr)
-	if err != nil || workerCount <= 0 {
-		logger.Warn(fmt.Sprintf("Invalid SWARMCD_CONCURRENCY value, using default: %v", defaultWorkers))
+	workerCount := config.Concurrency
+	if workerCount <= 0 {
+		logger.Warn(fmt.Sprintf("Invalid `config.Concurrency value`, using default: %v", defaultWorkers))
 
 		return defaultWorkers
 	}
 
 	return workerCount
 }
-
 func Run() {
 	logger.Info("starting SwarmCD")
 	for {

--- a/swarmcd/swarmcd.go
+++ b/swarmcd/swarmcd.go
@@ -15,7 +15,7 @@ const workerCount = 3 // Adjust this based on available CPU cores and workload
 func Run() {
 	logger.Info("starting SwarmCD")
 	for {
-		logger.Info("Checking if stack needs to be updated...")
+		logger.Debug("starting update loop")
 		var waitGroup sync.WaitGroup
 		stacksChannel := make(chan *swarmStack, len(stacks))
 
@@ -73,7 +73,7 @@ func updateStackThread(swarmStack *swarmStack) {
 	repoLock.Lock()
 	defer repoLock.Unlock()
 
-	logger.Info(fmt.Sprintf("%s updating stack", swarmStack.name))
+	logger.Info(fmt.Sprintf("%s checking if stack needs to be updated", swarmStack.name))
 	stackMetadata, err := swarmStack.updateStack()
 	if err != nil {
 		stackStatus[swarmStack.name].Error = err.Error()
@@ -85,7 +85,7 @@ func updateStackThread(swarmStack *swarmStack) {
 	stackStatus[swarmStack.name].Revision = stackMetadata.repoRevision
 	stackStatus[swarmStack.name].DeployedStackRevision = stackMetadata.deployedStackRevision
 	stackStatus[swarmStack.name].DeployedAt = stackMetadata.deployedAt.Format(time.RFC3339)
-	logger.Info(fmt.Sprintf("%s done updating stack", swarmStack.name))
+	logger.Debug(fmt.Sprintf("%s updateStackThreadDone", swarmStack.name))
 }
 
 func GetStackStatus() map[string]*StackStatus {

--- a/swarmcd/swarmcd.go
+++ b/swarmcd/swarmcd.go
@@ -10,7 +10,7 @@ import (
 var stackStatus = map[string]*StackStatus{}
 var stacks = map[string]*swarmStack{}
 
-const workerCount = 5 // Adjust this based on available CPU cores and workload
+const workerCount = 3 // Adjust this based on available CPU cores and workload
 
 func Run() {
 	logger.Info("starting SwarmCD")

--- a/swarmcd/swarmcd.go
+++ b/swarmcd/swarmcd.go
@@ -73,7 +73,7 @@ func updateStackThread(swarmStack *swarmStack) {
 	repoLock.Lock()
 	defer repoLock.Unlock()
 
-	logger.Info(fmt.Sprintf("%s checking if stack needs to be updated", swarmStack.name))
+	logger.Debug(fmt.Sprintf("%s checking if stack needs to be updated", swarmStack.name))
 	stackMetadata, err := swarmStack.updateStack()
 	if err != nil {
 		stackStatus[swarmStack.name].Error = err.Error()
@@ -85,7 +85,7 @@ func updateStackThread(swarmStack *swarmStack) {
 	stackStatus[swarmStack.name].Revision = stackMetadata.repoRevision
 	stackStatus[swarmStack.name].DeployedStackRevision = stackMetadata.deployedStackRevision
 	stackStatus[swarmStack.name].DeployedAt = stackMetadata.deployedAt.Format(time.RFC3339)
-	logger.Debug(fmt.Sprintf("%s updateStackThreadDone", swarmStack.name))
+	logger.Debug(fmt.Sprintf("%s updateStackThread done", swarmStack.name))
 }
 
 func GetStackStatus() map[string]*StackStatus {

--- a/swarmcd/swarmcd.go
+++ b/swarmcd/swarmcd.go
@@ -31,7 +31,7 @@ func Run() {
 
 		// Start worker pool
 		var workerCount = getWorkerCount()
-		logger.Info(fmt.Sprintf("worker count: %v", workerCount))
+		logger.Debug(fmt.Sprintf("worker count: %v", workerCount))
 
 		for i := 0; i < workerCount; i++ {
 			go worker(stacksChannel, &waitGroup)

--- a/util/config.go
+++ b/util/config.go
@@ -26,6 +26,7 @@ type RepoConfig struct {
 type Config struct {
 	ReposPath            string                  `mapstructure:"repos_path"`
 	UpdateInterval       int                     `mapstructure:"update_interval"`
+	Concurrency          int                     `mapstructure:"concurrency"`
 	AutoRotate           bool                    `mapstructure:"auto_rotate"`
 	StackConfigs         map[string]*StackConfig `mapstructure:"stacks"`
 	RepoConfigs          map[string]*RepoConfig  `mapstructure:"repos"`
@@ -58,6 +59,7 @@ func readConfig() (err error) {
 	configViper.SetConfigName("config")
 	configViper.AddConfigPath(".")
 	configViper.SetDefault("update_interval", 120)
+	configViper.SetDefault("concurrency", 3)
 	configViper.SetDefault("repos_path", "repos")
 	configViper.SetDefault("auto_rotate", true)
 	configViper.SetDefault("sops_secrets_discovery", false)


### PR DESCRIPTION
The concurrency can be adjusted with a new the new `Confic.Concurrency` value. 

Other small change: Downgrade some logs to make the logs better readable